### PR TITLE
feat: add nomutesting directive

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ The MIT License (MIT)
 
 Copyright (c) 2014 Markus Zimmermann
 Copyright (c) 2021 Avito
+Copyright (c) 2025 Leonid Boykov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cmd/go-mutesting/main.go
+++ b/cmd/go-mutesting/main.go
@@ -321,10 +321,12 @@ func mutate(
 	execs []string,
 	stats *models.Report,
 ) int {
+	skippedLines := mutesting.Skips(fset, src.(*ast.File))
+
 	for _, m := range mutators {
 		debug(opts, "Mutator %s", m.Name)
 
-		changed := mutesting.MutateWalk(pkg, info, node, m.Mutator)
+		changed := mutesting.MutateWalk(pkg, info, fset, node, m.Mutator, skippedLines)
 
 		for {
 			_, ok := <-changed

--- a/internal/importing/filepath_test.go
+++ b/internal/importing/filepath_test.go
@@ -2,9 +2,10 @@ package importing
 
 import (
 	"fmt"
-	"github.com/avito-tech/go-mutesting/internal/models"
 	"os"
 	"testing"
+
+	"github.com/avito-tech/go-mutesting/internal/models"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/test/mutator.go
+++ b/test/mutator.go
@@ -27,15 +27,17 @@ func Mutator(t *testing.T, m mutator.Mutator, testFile string, count int) {
 	src, fset, pkg, info, err := mutesting.ParseAndTypeCheckFile(testFile)
 	assert.Nil(t, err)
 
+	skippedLines := mutesting.Skips(fset, src)
+
 	// Mutate a non relevant node
 	assert.Nil(t, m(pkg, info, src))
 
 	// Count the actual mutations
-	n := mutesting.CountWalk(pkg, info, src, m)
+	n := mutesting.CountWalk(pkg, info, fset, src, m, skippedLines)
 	assert.Equal(t, count, n)
 
 	// Mutate all relevant nodes -> test whole mutation process
-	changed := mutesting.MutateWalk(pkg, info, src, m)
+	changed := mutesting.MutateWalk(pkg, info, fset, src, m, skippedLines)
 
 	for i := 0; i < count; i++ {
 		assert.True(t, <-changed)


### PR DESCRIPTION
This PR adds a support for the `//nomutesting` directive, which allows certain lines to be skipped. I find this much more handy than maintaining a long file on MD5 hashes.