### PR TITLE
fix(cleanup): remove useless file read

### DIFF
--- a/cmd/go-mutesting/debug_commands.go
+++ b/cmd/go-mutesting/debug_commands.go
@@ -15,7 +15,7 @@ var listFilesCommand = &cli.Command{
 	Name:  "list-files",
 	Usage: "List found files",
 	Action: func(ctx context.Context, c *cli.Command) error {
-		files, err := importing.FilesOfArgs(c.Args().Slice(), importing.Options{
+		files, err := importing.FilesOfArgs(ctx, c.Args().Slice(), importing.Options{
 			SkipFileWithoutTest:  c.Bool("skip-without-test"),
 			SkipFileWithBuildTag: c.Bool("skip-with-build-tags"),
 			GitMainBranch:        c.String("git-branch"),
@@ -46,7 +46,7 @@ var printASTCommand = &cli.Command{
 	Name:  "print-ast",
 	Usage: "Print the ASTs of all given files and exit",
 	Action: func(ctx context.Context, c *cli.Command) error {
-		files, err := importing.FilesOfArgs(c.Args().Slice(), importing.Options{
+		files, err := importing.FilesOfArgs(ctx, c.Args().Slice(), importing.Options{
 			SkipFileWithoutTest:  c.Bool("skip-without-test"),
 			SkipFileWithBuildTag: c.Bool("skip-with-build-tags"),
 			GitMainBranch:        c.String("git-branch"),

--- a/cmd/go-mutesting/main.go
+++ b/cmd/go-mutesting/main.go
@@ -332,7 +332,7 @@ func (s *suite) executeMutesting(ctx context.Context) error {
 func (s *suite) ExecuteMutesting(ctx context.Context) (*report.Report, error) {
 	var rep = new(report.Report)
 
-	files, err := importing.FilesOfArgs(s.opts.args, s.opts.importingOpts)
+	files, err := importing.FilesOfArgs(ctx, s.opts.args, s.opts.importingOpts)
 	if err != nil {
 		return nil, fmt.Errorf("load packages: %w", err)
 	}
@@ -406,14 +406,15 @@ func (s *suite) mutate(
 		log.Fatal(err)
 	}
 
-	for _, m := range s.mutators {
-		log.Printf("Mutator %s", m.Name)
+	for _, mut := range s.mutators {
+		log.Printf("Mutator %s", mut.Name)
 
-		mutesting.MutateWalk(pkg, node, m.Mutator, skippedLines, func() {
-			mutant := report.Mutant{}
-			mutant.Mutator.MutatorName = m.Name
-			mutant.Mutator.OriginalFilePath = originalFile
-			mutant.Mutator.OriginalSourceCode = string(originalSourceCode)
+		mutesting.MutateWalk(pkg, node, mut.Mutator, skippedLines, func() {
+			mutant := report.Mutant{Mutator: report.Mutator{
+				MutatorName:        mut.Name,
+				OriginalFilePath:   originalFile,
+				OriginalSourceCode: string(originalSourceCode),
+			}}
 
 			mutationFile := filepath.Join(tempDir, fmt.Sprintf("%s.%d", originalFile, mutationID))
 			checksum, duplicate, err := s.saveAST(mutationFile, pkg.Fset, src)
@@ -427,17 +428,17 @@ func (s *suite) mutate(
 				log.Printf("Save mutation into %q with checksum %s", mutationFile, checksum)
 
 				if !s.opts.noExec {
-					mutationError := s.mutateExec(ctx, pkg.Types, originalFile, mutationFile, &mutant)
-
-					if mutationError != nil {
-						slog.Info("exec mutation", slog.Any("error", mutationError))
-					}
-
 					mutatedSourceCode, err := os.ReadFile(mutationFile)
 					if err != nil {
 						log.Fatal(err)
 					}
 					mutant.Mutator.MutatedSourceCode = string(mutatedSourceCode)
+
+					mutationError := s.mutateExec(ctx, pkg.Types, originalFile, mutationFile, &mutant)
+
+					if mutationError != nil {
+						slog.Info("exec mutation", slog.Any("error", mutationError))
+					}
 
 					msg := fmt.Sprintf("%q #%d with checksum %s", originalFile, mutationID, checksum)
 

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -3,25 +3,11 @@ package diff
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/fatih/color"
 	"github.com/pmezard/go-difflib/difflib"
 )
-
-// CompareFiles reads files and computes a diff.
-func CompareFiles(origFilename, mutatedFilename, mutatorName string) (string, error) {
-	orig, err := os.ReadFile(origFilename)
-	if err != nil {
-		return "", fmt.Errorf("read original file: %w", err)
-	}
-	mutated, err := os.ReadFile(mutatedFilename)
-	if err != nil {
-		return "", fmt.Errorf("read mutated file: %w", err)
-	}
-	return CompareStrings(string(orig), string(mutated), mutatorName)
-}
 
 // CompareStrings computes a diff for two files.
 func CompareStrings(original, mutated, mutatorName string) (string, error) {

--- a/internal/execute/gotest.go
+++ b/internal/execute/gotest.go
@@ -36,7 +36,11 @@ type GoTestOptions struct {
 }
 
 func GoTest(ctx context.Context, mutant *report.Mutant, opts GoTestOptions) error {
-	diffStr, err := diff.CompareFiles(opts.Original, opts.Changed, mutant.Mutator.MutatorName)
+	diffStr, err := diff.CompareStrings(
+		mutant.Mutator.OriginalSourceCode,
+		mutant.Mutator.MutatedSourceCode,
+		mutant.Mutator.MutatorName,
+	)
 	if err != nil {
 		return fmt.Errorf("compare files: %w", err)
 	}

--- a/internal/importing/filepath.go
+++ b/internal/importing/filepath.go
@@ -1,6 +1,7 @@
 package importing
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"iter"
@@ -24,13 +25,14 @@ type Options struct {
 	ExcludeDirs          []string
 }
 
-func FilesOfArgs(args []string, opts Options) ([]string, error) {
+func FilesOfArgs(ctx context.Context, args []string, opts Options) ([]string, error) {
 	if len(args) == 0 {
 		args = []string{"."}
 	}
 	pkgs, err := packages.Load(&packages.Config{
-		Mode:  packages.NeedFiles,
-		Tests: false,
+		Context: ctx,
+		Mode:    packages.NeedFiles,
+		Tests:   false,
 	}, args...)
 	if err != nil {
 		return nil, fmt.Errorf("load packages: %w", err)

--- a/internal/importing/filepath_test.go
+++ b/internal/importing/filepath_test.go
@@ -71,7 +71,7 @@ func TestFilesOfArgs(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got, _ := FilesOfArgs(test.args, Options{})
+			got, _ := FilesOfArgs(t.Context(), test.args, Options{})
 
 			assert.Equal(t, test.expect, cleanupPaths(t, got), fmt.Sprintf("With args: %#v", test.args))
 		})
@@ -114,7 +114,7 @@ func TestFilesWithSkipWithoutTests(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got, _ := FilesOfArgs(test.args, Options{SkipFileWithoutTest: true})
+			got, _ := FilesOfArgs(t.Context(), test.args, Options{SkipFileWithoutTest: true})
 
 			assert.Equal(t, test.expect, cleanupPaths(t, got), fmt.Sprintf("With args: %#v", test.args))
 		})
@@ -158,7 +158,7 @@ func TestFilesWithSkipWithBuildTagsTests(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got, _ := FilesOfArgs(test.args, Options{SkipFileWithBuildTag: true})
+			got, _ := FilesOfArgs(t.Context(), test.args, Options{SkipFileWithBuildTag: true})
 
 			assert.Equal(t, test.expect, cleanupPaths(t, got), fmt.Sprintf("With args: %#v", test.args))
 		})
@@ -236,7 +236,7 @@ func TestFilesWithExcludedDirs(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got, _ := FilesOfArgs(test.args, Options{ExcludeDirs: test.config})
+			got, _ := FilesOfArgs(t.Context(), test.args, Options{ExcludeDirs: test.config})
 
 			assert.Equal(t, test.expect, cleanupPaths(t, got), fmt.Sprintf("With args: %#v", test.args))
 		})


### PR DESCRIPTION
This PR removes useless file reads and allows reusing data already stored in the report structure.